### PR TITLE
indentation for templates

### DIFF
--- a/Utils/Agents.py
+++ b/Utils/Agents.py
@@ -50,7 +50,7 @@ class Agent:
                     Patient's Report: {medical_report}
                 """
             }
-        templates = templates[self.role]
+            templates = templates[self.role]
         return PromptTemplate.from_template(templates)
     
     def run(self):


### PR DESCRIPTION
In the first scenario, templates is not a dictionary, so using templates = templates[self.role] would raise an error. Therefore, the indentation was adjusted to ensure this code only runs in the second scenario.